### PR TITLE
feat: [015] Enhance primary devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,25 @@
     "containerEnv": {
         "UV_LINK_MODE": "copy"
     },
-    "postCreateCommand": "pipx install uv && uv sync --all-extras"
+    "features": {
+        "ghcr.io/casey/just/just:latest": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+    "postCreateCommand": "pipx install uv && uv sync --all-extras && uv run pre-commit install",
+    "forwardPorts": [8000],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.mypy-type-checker",
+                "charliermarsh.ruff",
+                "tamasfe.even-better-toml",
+                "skellock.just"
+            ],
+            "settings": {
+                "editor.formatOnSave": true,
+                "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+            }
+        }
+    }
 }


### PR DESCRIPTION
# [015] Enhance Primary Devcontainer

## Description
This PR addresses Issue #15 by enriching the primary `devcontainer.json` configuration for better onboarding and development workflows.

## Changes Made
- Added `just` and `github-cli` via devcontainer features.
- Expanded `postCreateCommand` to automatically run `uv run pre-commit install`.
- Configured local port forwarding for `mkdocs serve` on port 8000.
- Specified recommended VS Code extensions for python, mypy, ruff, toml, and just.
- Set recommended VS Code workspace settings such as `editor.formatOnSave` and configured the python interpreter path.

Closes #15
