### PR TITLE
feat: [016] Add lightweight docs devcontainer

### DIFF
--- a/.devcontainer/docs/devcontainer.json
+++ b/.devcontainer/docs/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Vindicta Docs Environment",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+    "containerEnv": {
+        "UV_LINK_MODE": "copy"
+    },
+    "postCreateCommand": "pipx install uv && uv sync --all-extras",
+    "forwardPorts": [
+        8000
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "yzhang.markdown-all-in-one",
+                "DavidAnson.vscode-markdownlint"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# [016] Output Docs Devcontainer

## Description
This PR addresses Issue #16 by adding a lightweight `devcontainer.json` specifically tailored for documentation contributors. 

## Changes Made
- Created a new devcontainer in `.devcontainer/docs/` focusing exclusively on Markdown and MkDocs editing.
- Added automatic port forwarding for `mkdocs serve` (port 8000).
- Included extensions `yzhang.markdown-all-in-one` and `DavidAnson.vscode-markdownlint` for better docs authoring experience.

Closes #16
