### PR TITLE
feat: [017] Add CI debug devcontainer

### DIFF
--- a/.devcontainer/ci/devcontainer.json
+++ b/.devcontainer/ci/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "name": "Vindicta CI Debug",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+    "containerEnv": {
+        "UV_LINK_MODE": "copy",
+        "CI": "true"
+    },
+    "postCreateCommand": "pipx install uv && uv sync --all-extras && uv run pre-commit install"
+}


### PR DESCRIPTION
# [017] CI Debug Devcontainer

## Description
This PR addresses Issue #17 by adding a specialized `devcontainer.json` for strictly mimicking the GitHub Actions CI environment locally.

## Changes Made
- Created `.devcontainer/ci/devcontainer.json`.
- Set container `CI` environment variable to `"true"`.
- Added a comprehensive `postCreateCommand` to install `uv`, synchronize all extras, and strictly enforce the installation of `pre-commit` hooks upon container spin-up.

Closes #17
