### PR TITLE
feat: add dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,18 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    uses: vindicta-platform/.github/.github/workflows/dependency-audit-template.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Adds `dependency-audit.yml` calling the org-wide reusable template. Runs weekly on Monday and on PRs touching `pyproject.toml` or `uv.lock`.