### PR TITLE
fix: use pytest.approx() for float comparisons (S1244)

### DIFF
--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -22,8 +22,8 @@ def test_gas_tank_state_logic() -> None:
 def test_gas_tank_defaults() -> None:
     """Test the default instantiation of GasTankState."""
     tank = GasTankState(balance_usd=0.0, limit_usd=0.0, is_active=True)
-    assert tank.balance_usd == 0.0
-    assert tank.limit_usd == 0.0
+    assert tank.balance_usd == pytest.approx(0.0)
+    assert tank.limit_usd == pytest.approx(0.0)
     assert tank.is_active is True
     assert tank.is_empty is True
     assert tank.is_low is True


### PR DESCRIPTION
## Summary

Fix 2 bugs flagged by SonarCloud rule S1244 — floating-point equality comparisons in test assertions.

## Changes

- **`tests/test_economy.py`** (L25-26): Replaced `== 0.0` with `== pytest.approx(0.0)` for `balance_usd` and `limit_usd` assertions.

## SonarCloud Issues Resolved

| Rule | Severity | Count |
|------|----------|-------|
| S1244 | MEDIUM | 2 |